### PR TITLE
Fix duplicate layout for leadership assignments

### DIFF
--- a/index-pro.html
+++ b/index-pro.html
@@ -38,44 +38,36 @@
 
   <div id="tab-main">
 
-    <div class="board">
-      <div class="main">
-        <div class="lead-row">
-          <div class="slot" data-role="charge"></div>
-          <div class="slot" data-role="triage"></div>
+      <div class="board">
+        <div class="panel">
+          <div class="section">
+            <h3>Leadership</h3>
+            <div class="row">
+              <div class="slot" data-role="charge"></div>
+              <div class="slot" data-role="triage"></div>
+            </div>
+          </div>
+          <div class="section">
+            <h3>Assignments</h3>
+            <div id="zoneContainer"></div>
+          </div>
         </div>
-        <div id="zoneContainer"></div>
+        <aside class="side">
+          <div class="section">
+            <h3>Techs / Staff</h3>
+            <div id="supportList" class="listbox"></div>
+          </div>
+          <div class="section">
+            <h3>Incoming</h3>
+            <div id="incomingList" class="listbox"></div>
+          </div>
+          <div class="section">
+            <h3>Offgoing</h3>
+            <div id="offgoingList" class="listbox"></div>
+          </div>
+        </aside>
       </div>
-      <aside class="side">
-        <div class="section">
-          <h3>Techs / Staff</h3>
-          <div id="supportList" class="listbox"></div>
-        </div>
-        <div class="section">
-          <h3>Incoming</h3>
-          <div id="incomingList" class="listbox"></div>
-        </div>
-        <div class="section">
-          <h3>Offgoing</h3>
-          <div id="offgoingList" class="listbox"></div>
-        </div>
-      </aside>
-    </div>
-    <div class="info-bar" id="infoBar"></div>
-
-    <div class="panel">
-      <div class="section">
-        <h3>Leadership</h3>
-        <div class="row">
-          <div class="slot" data-role="charge"></div>
-          <div class="slot" data-role="triage"></div>
-        </div>
-      </div>
-      <div class="section">
-        <h3>Assignments</h3>
-        <div id="zoneContainer"></div>
-      </div>
-    </div>
+      <div class="info-bar" id="infoBar"></div>
 
   </div>
 

--- a/index.html
+++ b/index.html
@@ -38,44 +38,36 @@
 
   <div id="tab-main">
 
-    <div class="board">
-      <div class="main">
-        <div class="lead-row">
-          <div class="slot" data-role="charge"></div>
-          <div class="slot" data-role="triage"></div>
+      <div class="board">
+        <div class="panel">
+          <div class="section">
+            <h3>Leadership</h3>
+            <div class="row">
+              <div class="slot" data-role="charge"></div>
+              <div class="slot" data-role="triage"></div>
+            </div>
+          </div>
+          <div class="section">
+            <h3>Assignments</h3>
+            <div id="zoneContainer"></div>
+          </div>
         </div>
-        <div id="zoneContainer"></div>
+        <aside class="side">
+          <div class="section">
+            <h3>Techs / Staff</h3>
+            <div id="supportList" class="listbox"></div>
+          </div>
+          <div class="section">
+            <h3>Incoming</h3>
+            <div id="incomingList" class="listbox"></div>
+          </div>
+          <div class="section">
+            <h3>Offgoing</h3>
+            <div id="offgoingList" class="listbox"></div>
+          </div>
+        </aside>
       </div>
-      <aside class="side">
-        <div class="section">
-          <h3>Techs / Staff</h3>
-          <div id="supportList" class="listbox"></div>
-        </div>
-        <div class="section">
-          <h3>Incoming</h3>
-          <div id="incomingList" class="listbox"></div>
-        </div>
-        <div class="section">
-          <h3>Offgoing</h3>
-          <div id="offgoingList" class="listbox"></div>
-        </div>
-      </aside>
-    </div>
-    <div class="info-bar" id="infoBar"></div>
-
-    <div class="panel">
-      <div class="section">
-        <h3>Leadership</h3>
-        <div class="row">
-          <div class="slot" data-role="charge"></div>
-          <div class="slot" data-role="triage"></div>
-        </div>
-      </div>
-      <div class="section">
-        <h3>Assignments</h3>
-        <div id="zoneContainer"></div>
-      </div>
-    </div>
+      <div class="info-bar" id="infoBar"></div>
 
   </div>
 


### PR DESCRIPTION
## Summary
- Move Leadership and Assignments panel into main board next to other boxes
- Remove duplicate elements causing broken interactions
- Allow clicking leadership slots or zone cards to enter nurse IDs and save assignments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4ca6fd9083278ba47e1abc560510