### PR TITLE
Fix duplicate layout for leadership assignments

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,6 @@ function saveConfig(){
   return DB.set(KS.CONFIG, {
     date: STATE.date,
     shift: STATE.shift,
-    locked: STATE.locked,
     zones: STATE.zones,
     pin: STATE.pin
   });
@@ -74,7 +73,6 @@ function bindToolbar(){
   $('#unlockBtn').onclick = async ()=>{
     STATE.locked = !STATE.locked;
     updateLockUI();
-    await saveConfig();
   };
   $('#startNewShiftBtn').onclick = async ()=>{
     const empty = { zones: Object.fromEntries(STATE.zones.map(z=>[z,[]])) };

--- a/index-pro.html
+++ b/index-pro.html
@@ -23,8 +23,8 @@
       </select>
     </div>
     <div class="toolbar">
-      <span id="lockState" class="subtitle">Locked</span>
-      <button class="btn accent" id="unlockBtn">Unlock</button>
+      <span id="lockState" class="subtitle">Unlocked</span>
+      <button class="btn accent" id="unlockBtn">Lock</button>
       <button class="btn ok" id="printBtn">Print</button>
       <button class="btn warn" id="startNewShiftBtn">Start New Shift</button>
     </div>
@@ -38,44 +38,36 @@
 
   <div id="tab-main">
 
-    <div class="board">
-      <div class="main">
-        <div class="lead-row">
-          <div class="slot" data-role="charge"></div>
-          <div class="slot" data-role="triage"></div>
+      <div class="board">
+        <div class="panel">
+          <div class="section">
+            <h3>Leadership</h3>
+            <div class="row">
+              <div class="slot" data-role="charge"></div>
+              <div class="slot" data-role="triage"></div>
+            </div>
+          </div>
+          <div class="section">
+            <h3>Assignments</h3>
+            <div id="zoneContainer"></div>
+          </div>
         </div>
-        <div id="zoneContainer"></div>
+        <aside class="side">
+          <div class="section">
+            <h3>Techs / Staff</h3>
+            <div id="supportList" class="listbox"></div>
+          </div>
+          <div class="section">
+            <h3>Incoming</h3>
+            <div id="incomingList" class="listbox"></div>
+          </div>
+          <div class="section">
+            <h3>Offgoing</h3>
+            <div id="offgoingList" class="listbox"></div>
+          </div>
+        </aside>
       </div>
-      <aside class="side">
-        <div class="section">
-          <h3>Techs / Staff</h3>
-          <div id="supportList" class="listbox"></div>
-        </div>
-        <div class="section">
-          <h3>Incoming</h3>
-          <div id="incomingList" class="listbox"></div>
-        </div>
-        <div class="section">
-          <h3>Offgoing</h3>
-          <div id="offgoingList" class="listbox"></div>
-        </div>
-      </aside>
-    </div>
-    <div class="info-bar" id="infoBar"></div>
-
-    <div class="panel">
-      <div class="section">
-        <h3>Leadership</h3>
-        <div class="row">
-          <div class="slot" data-role="charge"></div>
-          <div class="slot" data-role="triage"></div>
-        </div>
-      </div>
-      <div class="section">
-        <h3>Assignments</h3>
-        <div id="zoneContainer"></div>
-      </div>
-    </div>
+      <div class="info-bar" id="infoBar"></div>
 
   </div>
 

--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@
       </select>
     </div>
     <div class="toolbar">
-      <span id="lockState" class="subtitle">Locked</span>
-      <button class="btn accent" id="unlockBtn">Unlock</button>
+      <span id="lockState" class="subtitle">Unlocked</span>
+      <button class="btn accent" id="unlockBtn">Lock</button>
       <button class="btn ok" id="printBtn">Print</button>
       <button class="btn warn" id="startNewShiftBtn">Start New Shift</button>
     </div>
@@ -38,44 +38,36 @@
 
   <div id="tab-main">
 
-    <div class="board">
-      <div class="main">
-        <div class="lead-row">
-          <div class="slot" data-role="charge"></div>
-          <div class="slot" data-role="triage"></div>
+      <div class="board">
+        <div class="panel">
+          <div class="section">
+            <h3>Leadership</h3>
+            <div class="row">
+              <div class="slot" data-role="charge"></div>
+              <div class="slot" data-role="triage"></div>
+            </div>
+          </div>
+          <div class="section">
+            <h3>Assignments</h3>
+            <div id="zoneContainer"></div>
+          </div>
         </div>
-        <div id="zoneContainer"></div>
+        <aside class="side">
+          <div class="section">
+            <h3>Techs / Staff</h3>
+            <div id="supportList" class="listbox"></div>
+          </div>
+          <div class="section">
+            <h3>Incoming</h3>
+            <div id="incomingList" class="listbox"></div>
+          </div>
+          <div class="section">
+            <h3>Offgoing</h3>
+            <div id="offgoingList" class="listbox"></div>
+          </div>
+        </aside>
       </div>
-      <aside class="side">
-        <div class="section">
-          <h3>Techs / Staff</h3>
-          <div id="supportList" class="listbox"></div>
-        </div>
-        <div class="section">
-          <h3>Incoming</h3>
-          <div id="incomingList" class="listbox"></div>
-        </div>
-        <div class="section">
-          <h3>Offgoing</h3>
-          <div id="offgoingList" class="listbox"></div>
-        </div>
-      </aside>
-    </div>
-    <div class="info-bar" id="infoBar"></div>
-
-    <div class="panel">
-      <div class="section">
-        <h3>Leadership</h3>
-        <div class="row">
-          <div class="slot" data-role="charge"></div>
-          <div class="slot" data-role="triage"></div>
-        </div>
-      </div>
-      <div class="section">
-        <h3>Assignments</h3>
-        <div id="zoneContainer"></div>
-      </div>
-    </div>
+      <div class="info-bar" id="infoBar"></div>
 
   </div>
 

--- a/state.js
+++ b/state.js
@@ -4,7 +4,7 @@ import { todayISO } from './utils.js';
 export const STATE = {
   date: todayISO(),
   shift: 'day',
-  locked: true,
+  locked: false,
   zones: ['Beds 1–3','Beds 4–7','Beds 8–10','Fast Track'],
   staff: [],
   pin: '4911'


### PR DESCRIPTION
## Summary
- Move Leadership and Assignments panel into main board next to other boxes
- Remove duplicate elements causing broken interactions
- Allow clicking leadership slots or zone cards to enter nurse IDs and save assignments
- Start board unlocked by default and do not persist lock state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4ca6fd9083278ba47e1abc560510