### PR TITLE
feat: add interface customization settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,18 @@ import { DB, KS } from './db.js';
 import { STATE } from './state.js';
 import { renderAll, renderPending } from './render.js';
 
+const ACCENTS={
+  blue:'#0090ff',
+  green:'#28c990',
+  orange:'#f5a524',
+  purple:'#b259d0',
+  pink:'#ff5b9a'
+};
+
+function applyInterface(){
+  document.documentElement.dataset.theme=STATE.theme;
+  document.documentElement.style.setProperty('--accent', ACCENTS[STATE.accent]||ACCENTS.blue);
+}
 
 function saveConfig(){
   return DB.set(KS.CONFIG, {
@@ -11,7 +23,9 @@ function saveConfig(){
     shift: STATE.shift,
     locked: STATE.locked,
     zones: STATE.zones,
-    pin: STATE.pin
+    pin: STATE.pin,
+    theme: STATE.theme,
+    accent: STATE.accent
   });
 }
 
@@ -83,17 +97,34 @@ function bindToolbar(){
   };
 }
 
+function bindInterface(){
+  $('#themeSel').value = STATE.theme;
+  $('#accentSel').value = STATE.accent;
+  $('#themeSel').onchange = async e=>{
+    STATE.theme = e.target.value;
+    applyInterface();
+    await saveConfig();
+  };
+  $('#accentSel').onchange = async e=>{
+    STATE.accent = e.target.value;
+    applyInterface();
+    await saveConfig();
+  };
+}
+
 
 async function init(){
   const cfg=await DB.get(KS.CONFIG); if(cfg) Object.assign(STATE,cfg);
   const staff=await DB.get(KS.STAFF); if(staff) STATE.staff=staff;
   $('#datePicker').value=STATE.date; $('#shiftSel').value=STATE.shift;
 
+  applyInterface();
   updateDateLabel();
   updateLockUI();
   bindTabs();
   bindPending();
   bindToolbar();
+  bindInterface();
 
   bindTabs(); bindPending();
 

--- a/index-pro.html
+++ b/index-pro.html
@@ -108,6 +108,26 @@
 
   <div id="tab-settings" style="display:none">
     <div class="panel">
+      <h3>Interface</h3>
+      <div class="row">
+        <label for="themeSel">Theme</label>
+        <select id="themeSel" class="select">
+          <option value="dark">Dark</option>
+          <option value="light">Light</option>
+        </select>
+      </div>
+      <div class="row">
+        <label for="accentSel">Accent</label>
+        <select id="accentSel" class="select">
+          <option value="blue">Blue</option>
+          <option value="green">Green</option>
+          <option value="orange">Orange</option>
+          <option value="purple">Purple</option>
+          <option value="pink">Pink</option>
+        </select>
+      </div>
+    </div>
+    <div class="panel">
       <h3>Nurses</h3>
       <div id="nurseList" class="listbox"></div>
     </div>

--- a/index.html
+++ b/index.html
@@ -108,6 +108,26 @@
 
   <div id="tab-settings" style="display:none">
     <div class="panel">
+      <h3>Interface</h3>
+      <div class="row">
+        <label for="themeSel">Theme</label>
+        <select id="themeSel" class="select">
+          <option value="dark">Dark</option>
+          <option value="light">Light</option>
+        </select>
+      </div>
+      <div class="row">
+        <label for="accentSel">Accent</label>
+        <select id="accentSel" class="select">
+          <option value="blue">Blue</option>
+          <option value="green">Green</option>
+          <option value="orange">Orange</option>
+          <option value="purple">Purple</option>
+          <option value="pink">Pink</option>
+        </select>
+      </div>
+    </div>
+    <div class="panel">
       <h3>Nurses</h3>
       <div id="nurseList" class="listbox"></div>
     </div>

--- a/state.js
+++ b/state.js
@@ -7,7 +7,9 @@ export const STATE = {
   locked: true,
   zones: ['Beds 1–3','Beds 4–7','Beds 8–10','Fast Track'],
   staff: [],
-  pin: '4911'
+  pin: '4911',
+  theme: 'dark',
+  accent: 'blue'
 };
 
 export const getById = id => STATE.staff.find(s=>s.id===id);

--- a/styles-pro.css
+++ b/styles-pro.css
@@ -6,7 +6,7 @@
   --tab:#f0f3f8;
   --text:#1a2233;
   --muted:#6b778c;
-  --accent:#0066ff;
+  --accent:#0090ff;
   --ok:#27ae60;
   --warn:#f39c12;
   --danger:#e74c3c;
@@ -19,6 +19,19 @@
   --f-lg:clamp(20px,1.4vw,26px);
   --f-xl:clamp(28px,2.2vw,36px);
 }
+:root[data-theme='dark']{
+  --bg:#080b10;
+  --panel:#141b2c;
+  --control:#101624;
+  --tab:#0f1522;
+  --text:#ffffff;
+  --muted:#9aa8be;
+  --ok:#28c990;
+  --warn:#f5a524;
+  --danger:#ef5b5b;
+  --line:#273044;
+  --slot:#111726;
+}
 *{box-sizing:border-box}
 html,body{height:100%}
 body{margin:0;background:var(--bg);color:var(--text);font-family:Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial}
@@ -29,7 +42,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .toolbar{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
 .btn,.input,.select,textarea{border-radius:12px;border:1px solid var(--line);background:var(--control);color:var(--text);padding:10px 12px;font-size:var(--f);}
 .btn{height:44px;cursor:pointer;user-select:none}
-.btn.accent{background:var(--accent);border-color:#0054d1;color:#ffffff;font-weight:700}
+.btn.accent{background:var(--accent);border-color:var(--accent);color:#ffffff;font-weight:700}
 .btn.ok{background:var(--ok);border-color:#1b9a70;color:#ffffff;font-weight:700}
 .btn.warn{background:var(--warn);border-color:#c88415;color:#ffffff;font-weight:700}
 .tabs{display:flex;gap:8px;margin-bottom:var(--gap)}

--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,19 @@
   --f-lg:clamp(20px,1.4vw,26px);
   --f-xl:clamp(28px,2.2vw,36px);
 }
+:root[data-theme='light']{
+  --bg:#f5f7fa;
+  --panel:#ffffff;
+  --control:#ffffff;
+  --tab:#f0f3f8;
+  --text:#1a2233;
+  --muted:#6b778c;
+  --ok:#27ae60;
+  --warn:#f39c12;
+  --danger:#e74c3c;
+  --line:#dce1eb;
+  --slot:#f5f8ff;
+}
 *{box-sizing:border-box}
 html,body{height:100%}
 body{margin:0;background:var(--bg);color:var(--text);font-family:Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial}
@@ -29,7 +42,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .toolbar{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
 .btn,.input,.select,textarea{border-radius:12px;border:1px solid var(--line);background:var(--control);color:var(--text);padding:10px 12px;font-size:var(--f);}
 .btn{height:44px;cursor:pointer;user-select:none}
-.btn.accent{background:var(--accent);border-color:#0065cc;color:#ffffff;font-weight:700}
+.btn.accent{background:var(--accent);border-color:var(--accent);color:#ffffff;font-weight:700}
 .btn.ok{background:var(--ok);border-color:#1b9a70;color:#04150f;font-weight:700}
 .btn.warn{background:var(--warn);border-color:#c88415;color:#1b1203;font-weight:700}
 .tabs{display:flex;gap:8px;margin-bottom:var(--gap)}


### PR DESCRIPTION
## Summary
- allow selecting light or dark theme and five accent colors from Settings
- persist theme and accent selections to configuration
- support dynamic themes and accents in styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f5012920c8327bdc43393ff470a5a