### PR TITLE
Improve initialization to allow clicking

### DIFF
--- a/app.js
+++ b/app.js
@@ -145,19 +145,26 @@ function bindInterface(){
 
 
 async function init(){
-  const cfg=await DB.get(KS.CONFIG); if(cfg) Object.assign(STATE,cfg);
-  const staff=await DB.get(KS.STAFF); if(staff) STATE.staff=staff;
-  $('#datePicker').value=STATE.date; $('#shiftSel').value=STATE.shift;
+  try{
+    const cfg=await DB.get(KS.CONFIG);
+    if(cfg) Object.assign(STATE,cfg);
+    const staff=await DB.get(KS.STAFF);
+    if(staff) STATE.staff=staff;
+  }catch(err){
+    console.error('DB init error', err);
+  }
+
+  $('#datePicker').value=STATE.date;
+  $('#shiftSel').value=STATE.shift;
 
   applyInterface();
   updateDateLabel();
   updateLockUI();
+
   bindTabs();
   bindPending();
   bindToolbar();
   bindInterface();
-
-  bindTabs(); bindPending();
 
   renderTimeWeather();
   fetchWeather();

--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@
 </div>
 
 <script type="module" src="app.js"></script>
+<script nomodule src="bundle.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Load bundled script as a fallback when browsers can't execute ES modules
- Wrap database initialization in try/catch so UI still binds even if storage fails
- Clean up duplicate tab/pending bindings during startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f5a8229c08327b1d9e7af32556f4f