### PR TITLE
feat: add TV-mode scaling and right-side rail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,23 +2,39 @@ import React, { useEffect, useState } from 'react';
 import Board from './components/Board';
 import TopBar from './components/TopBar';
 import Settings from './components/Settings';
+import RightRail from './components/RightRail';
+import ViewportScaler from './components/ViewportScaler';
 import { useStore } from './store';
 
 const App: React.FC = () => {
-  const theme = useStore((s) => s.theme);
-  const setTheme = useStore((s) => s.setTheme);
+  const settings = useStore((s) => s.settings);
+  const updateSettings = useStore((s) => s.updateSettings);
   const [showSettings, setShowSettings] = useState(false);
 
   useEffect(() => {
-    document.documentElement.dataset.theme = theme;
-  }, [theme]);
+    document.documentElement.dataset.theme = settings.theme;
+  }, [settings.theme]);
 
   return (
-    <div className="app">
-      <TopBar onOpenSettings={() => setShowSettings(true)} onToggleTheme={() => setTheme(theme === 'dark' ? 'light' : 'dark')} />
-      <Board />
-      {showSettings && <Settings onClose={() => setShowSettings(false)} />}
-    </div>
+    <ViewportScaler width={1920} height={1080}>
+      <div className={`app-root ${settings.tvMode ? 'tv-mode' : ''}`}>
+        <TopBar
+          tvMode={settings.tvMode}
+          onToggleTvMode={() => updateSettings({ tvMode: !settings.tvMode })}
+          onOpenSettings={() => setShowSettings(true)}
+          onToggleTheme={() =>
+            updateSettings({
+              theme: settings.theme === 'dark' ? 'light' : 'dark',
+            })
+          }
+        />
+        <div className="main-grid">
+          <Board />
+          <RightRail />
+        </div>
+        {showSettings && <Settings onClose={() => setShowSettings(false)} />}
+      </div>
+    </ViewportScaler>
   );
 };
 

--- a/src/components/RightRail.tsx
+++ b/src/components/RightRail.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import CardTimeWeather from './card/CardTimeWeather';
+import CardIncoming from './card/CardIncoming';
+import CardOffgoing from './card/CardOffgoing';
+import CardAncillary from './card/CardAncillary';
+
+const RightRail: React.FC = () => {
+  return (
+    <aside className="right-rail">
+      <CardTimeWeather />
+      <CardIncoming />
+      <CardOffgoing />
+      <CardAncillary />
+    </aside>
+  );
+};
+
+export default RightRail;

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -5,9 +5,11 @@ import { displayName } from '../utils/name';
 interface Props {
   onOpenSettings: () => void;
   onToggleTheme: () => void;
+  onToggleTvMode: () => void;
+  tvMode: boolean;
 }
 
-const TopBar: React.FC<Props> = ({ onOpenSettings, onToggleTheme }) => {
+const TopBar: React.FC<Props> = ({ onOpenSettings, onToggleTheme, onToggleTvMode, tvMode }) => {
   const [query, setQuery] = useState('');
   const nurses = useStore((s) => Object.values(s.nurses));
   const results = query
@@ -19,16 +21,19 @@ const TopBar: React.FC<Props> = ({ onOpenSettings, onToggleTheme }) => {
     : [];
 
   return (
-    <header className="topbar">
-      <button onClick={onOpenSettings}>⚙️</button>
-      <input
-        className="search"
-        placeholder="Search"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-      />
+    <header className={`topbar ${tvMode ? 'tv' : ''}`}>
+      {!tvMode && <button onClick={onOpenSettings}>⚙️</button>}
+      {!tvMode && (
+        <input
+          className="search"
+          placeholder="Search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      )}
       <button onClick={onToggleTheme}>🌓</button>
-      {query && (
+      <button onClick={onToggleTvMode}>{tvMode ? '↩️' : '📺'}</button>
+      {!tvMode && query && (
         <div className="search-results">
           {results.map((n) => (
             <div key={n.id}>{displayName(n, 'full')}</div>

--- a/src/components/ViewportScaler.tsx
+++ b/src/components/ViewportScaler.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+
+interface Props {
+  width: number;
+  height: number;
+  children: React.ReactNode;
+}
+
+const ViewportScaler: React.FC<Props> = ({ width, height, children }) => {
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    const update = () => {
+      const w = window.innerWidth / width;
+      const h = window.innerHeight / height;
+      setScale(Math.min(w, h));
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, [width, height]);
+
+  return (
+    <div
+      style={{
+        width: '100vw',
+        height: '100vh',
+        overflow: 'hidden',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        style={{
+          width,
+          height,
+          transform: `scale(${scale})`,
+          transformOrigin: 'top left',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default ViewportScaler;

--- a/src/components/card/CardAncillary.tsx
+++ b/src/components/card/CardAncillary.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { useStore } from '../../store';
+import { Role } from '../../types';
+
+const CardAncillary: React.FC = () => {
+  const ancillary = useStore((s) => s.ancillary);
+  const addAncillary = useStore((s) => s.addAncillary);
+  const [role, setRole] = useState<Role>('RT');
+  const [names, setNames] = useState('');
+  const [note, setNote] = useState('');
+
+  const handleAdd = () => {
+    if (!names.trim()) return;
+    addAncillary(
+      role,
+      names.split(',').map((n) => n.trim()).filter(Boolean),
+      note || undefined
+    );
+    setNames('');
+    setNote('');
+  };
+
+  return (
+    <div className="rail-card ancillary">
+      <h3>Ancillary Staff</h3>
+      {ancillary.length === 0 ? (
+        <div className="empty">None</div>
+      ) : (
+        <ul>
+          {ancillary.map((a) => (
+            <li key={a.id}>
+              <strong>{a.role}:</strong> {a.names.join(', ')}{' '}
+              {a.note && `– ${a.note}`}
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="add-row">
+        <select value={role} onChange={(e) => setRole(e.target.value as Role)}>
+          <option value="RT">RT</option>
+          <option value="Rad">Rad</option>
+          <option value="Transport">Transport</option>
+          <option value="Scribe">Scribe</option>
+          <option value="Other">Other</option>
+        </select>
+        <input
+          placeholder="Names"
+          value={names}
+          onChange={(e) => setNames(e.target.value)}
+        />
+        <input
+          placeholder="Note"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+        />
+        <button onClick={handleAdd}>+ Add</button>
+      </div>
+    </div>
+  );
+};
+
+export default CardAncillary;

--- a/src/components/card/CardIncoming.tsx
+++ b/src/components/card/CardIncoming.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useScheduleBuckets } from '../../hooks/useScheduleBuckets';
+import { displayName } from '../../utils/name';
+
+const CardIncoming: React.FC = () => {
+  const { incoming } = useScheduleBuckets();
+
+  return (
+    <div className="rail-card incoming">
+      <h3>Incoming Staff</h3>
+      {incoming.length === 0 ? (
+        <div className="empty">None</div>
+      ) : (
+        <ul>
+          {incoming.map((n) => (
+            <li key={n.id}>
+              {displayName(n)} – {n.role}{' '}
+              {n.rfNumber && `RF ${n.rfNumber}`} (starts{' '}
+              {n.shiftStart &&
+                new Date(n.shiftStart).toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              )
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default CardIncoming;

--- a/src/components/card/CardOffgoing.tsx
+++ b/src/components/card/CardOffgoing.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useScheduleBuckets } from '../../hooks/useScheduleBuckets';
+import { displayName } from '../../utils/name';
+
+const CardOffgoing: React.FC = () => {
+  const { offgoing } = useScheduleBuckets();
+  return (
+    <div className="rail-card offgoing">
+      <h3>Off-going Staff</h3>
+      {offgoing.length === 0 ? (
+        <div className="empty">None</div>
+      ) : (
+        <ul>
+          {offgoing.map((n) => (
+            <li key={n.id}>
+              {displayName(n)} – {n.role}{' '}
+              {n.rfNumber && `RF ${n.rfNumber}`} (off at{' '}
+              {new Date((n.shiftEnd || n.offAt)!).toLocaleTimeString([], {
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+              )
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default CardOffgoing;

--- a/src/components/card/CardTimeWeather.tsx
+++ b/src/components/card/CardTimeWeather.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { useStore } from '../../store';
+import { useWeather } from '../../hooks/useWeather';
+
+const pad = (n: number) => n.toString().padStart(2, '0');
+
+const CardTimeWeather: React.FC = () => {
+  const settings = useStore((s) => s.settings);
+  const weather = useWeather();
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const id = setInterval(
+      () => setNow(new Date()),
+      settings.showSeconds ? 1000 : 60000
+    );
+    return () => clearInterval(id);
+  }, [settings.showSeconds]);
+
+  const hours = settings.clock24h
+    ? now.getHours()
+    : (now.getHours() % 12) || 12;
+  const minutes = now.getMinutes();
+  const seconds = now.getSeconds();
+  const timeStr = `${pad(hours)}:${pad(minutes)}${settings.showSeconds ? ':' + pad(seconds) : ''}`;
+  const dateStr = now.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  return (
+    <div className="rail-card time-weather">
+      <div className="clock">{timeStr}</div>
+      <div className="date">{dateStr}</div>
+      {settings.weatherEnabled ? (
+        weather && weather.tempF !== undefined ? (
+          <div className="weather">
+            <div className="loc">
+              {settings.weatherLocationLabel || weather.location}
+            </div>
+            <div className="temp">{weather.tempF}&deg;F</div>
+          </div>
+        ) : (
+          <div className="weather-placeholder">No weather source configured</div>
+        )
+      ) : (
+        <div className="weather-placeholder">Weather disabled</div>
+      )}
+    </div>
+  );
+};
+
+export default CardTimeWeather;

--- a/src/hooks/useScheduleBuckets.ts
+++ b/src/hooks/useScheduleBuckets.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { useStore } from '../store';
+import { Nurse } from '../types';
+
+const MS = 60 * 1000;
+
+export interface Buckets {
+  incoming: Nurse[];
+  offgoing: Nurse[];
+}
+
+export function useScheduleBuckets(): Buckets {
+  const nurses = useStore((s) => Object.values(s.nurses));
+
+  const compute = () => {
+    const now = Date.now();
+    const incoming = nurses.filter(
+      (n) =>
+        n.status === 'off' &&
+        n.shiftStart &&
+        new Date(n.shiftStart).getTime() > now &&
+        new Date(n.shiftStart).getTime() - now <= 120 * MS
+    );
+    const offgoing = nurses.filter(
+      (n) =>
+        n.status === 'active' &&
+        (n.shiftEnd || n.offAt) &&
+        (() => {
+          const end = new Date(n.shiftEnd || n.offAt!).getTime();
+          return end > now && end - now <= 60 * MS;
+        })()
+    );
+    return { incoming, offgoing };
+  };
+
+  const [buckets, setBuckets] = useState<Buckets>(compute);
+
+  useEffect(() => {
+    const id = setInterval(() => setBuckets(compute()), 30000);
+    return () => clearInterval(id);
+  }, [nurses]);
+
+  return buckets;
+}

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useStore } from '../store';
+import { WeatherState } from '../types';
+
+export function useWeather(): WeatherState {
+  const settings = useStore((s) => s.settings);
+  const weather = useStore((s) => s.weather);
+  const setWeather = useStore((s) => s.setWeather);
+
+  useEffect(() => {
+    if (!settings.weatherEnabled || !settings.weatherEndpoint) return;
+    let cancelled = false;
+    const fetchWeather = () => {
+      fetch(settings.weatherEndpoint!)
+        .then((r) => r.json())
+        .then((data) => {
+          if (!cancelled) setWeather(data);
+        })
+        .catch(() => {});
+    };
+    fetchWeather();
+    const id = setInterval(fetchWeather, 15 * 60 * 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [settings.weatherEnabled, settings.weatherEndpoint, setWeather]);
+
+  return weather;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { BoardState, Nurse, Zone } from './types';
+import { BoardState, Nurse, Zone, Settings, WeatherState, Role } from './types';
 import { v4 as uuid } from 'uuid';
 
 const now = Date.now();
@@ -19,19 +19,29 @@ const demoState: BoardState = {
   nurses: {
     n1: { id: 'n1', firstName: 'Alice', lastName: 'Smith', rfNumber: '101', role: 'RN', status: 'active', offAt: new Date(now + 45 * 60000).toISOString() },
     n2: { id: 'n2', firstName: 'Bob', lastName: 'Jones', role: 'RN', status: 'active' },
-    n3: { id: 'n3', firstName: 'Carla', lastName: 'White', role: 'LPN', status: 'active', studentTag: 'S' },
-    n4: { id: 'n4', firstName: 'Dan', lastName: 'Brown', role: 'Charge', status: 'active' },
+    n3: { id: 'n3', firstName: 'Carla', lastName: 'White', role: 'RN', status: 'active', studentTag: 'S' },
+    n4: { id: 'n4', firstName: 'Dan', lastName: 'Brown', role: 'Charge RN', status: 'active' },
     n5: { id: 'n5', firstName: 'Eve', lastName: 'Miller', role: 'Tech', status: 'active', offAt: new Date(now + 30 * 60000).toISOString() },
     n6: { id: 'n6', firstName: 'Frank', lastName: 'Wilson', role: 'RN', status: 'active' },
     n7: { id: 'n7', firstName: 'Grace', lastName: 'Taylor', role: 'RN', status: 'active', studentTag: 'S' },
     n8: { id: 'n8', firstName: 'Hank', lastName: 'Anderson', role: 'Tech', status: 'active' },
     n9: { id: 'n9', firstName: 'Ivy', lastName: 'Thomas', role: 'RN', status: 'active' },
-    n10:{ id: 'n10', firstName: 'John', lastName: 'Lee', role: 'UnitSecretary', status: 'active' }
+    n10:{ id: 'n10', firstName: 'John', lastName: 'Lee', role: 'Other', status: 'active' }
   },
-  theme: 'dark',
+  ancillary: [],
+  settings: {
+    theme: 'dark',
+    tvMode: false,
+    showSeconds: true,
+    clock24h: false,
+    weatherEnabled: false,
+    autoPromoteIncoming: false,
+    retainOffgoingMinutes: 30,
+  },
+  weather: { location: '' },
   privacy: { mainBoardNameFormat: 'first-lastInitial' },
   ui: { density: 'comfortable' },
-  version: 1
+  version: 1,
 };
 
 interface Store extends BoardState {
@@ -41,45 +51,69 @@ interface Store extends BoardState {
   removeNurse: (id: string) => void;
   addZone: (name: string) => void;
   updateZone: (id: string, data: Partial<Zone>) => void;
-  setTheme: (t: 'dark' | 'light') => void;
+  updateSettings: (data: Partial<Settings>) => void;
+  setWeather: (w: Partial<WeatherState>) => void;
+  addAncillary: (role: Role, names: string[], note?: string) => void;
 }
 
-export const useStore = create<Store>()(persist((set, get) => ({
-  ...demoState,
-  addNurse: (nurse, zoneId = 'unassigned') => {
-    const id = nurse.id ?? uuid();
-    const n: Nurse = { status: 'active', ...nurse, id };
-    set((state) => {
-      state.nurses[id] = n;
-      const zone = state.zones.find((z) => z.id === zoneId);
-      zone?.nurseIds.push(id);
-    });
-    return id;
-  },
-  updateNurse: (id, data) => set((state) => { state.nurses[id] = { ...state.nurses[id], ...data }; }),
-  moveNurse: (id, toZone, index) => set((state) => {
-    const fromZone = state.zones.find((z) => z.nurseIds.includes(id));
-    if (fromZone) fromZone.nurseIds = fromZone.nurseIds.filter((nid) => nid !== id);
-    const zone = state.zones.find((z) => z.id === toZone);
-    if (zone) {
-      if (index === undefined) zone.nurseIds.push(id); else zone.nurseIds.splice(index, 0, id);
+export const useStore = create<Store>()(
+  persist(
+    (set, get) => ({
+      ...demoState,
+      addNurse: (nurse, zoneId = 'unassigned') => {
+        const id = nurse.id ?? uuid();
+        const n: Nurse = { status: 'active', ...nurse, id };
+        set((state) => {
+          state.nurses[id] = n;
+          const zone = state.zones.find((z) => z.id === zoneId);
+          zone?.nurseIds.push(id);
+        });
+        return id;
+      },
+      updateNurse: (id, data) =>
+        set((state) => {
+          state.nurses[id] = { ...state.nurses[id], ...data };
+        }),
+      moveNurse: (id, toZone, index) =>
+        set((state) => {
+          const fromZone = state.zones.find((z) => z.nurseIds.includes(id));
+          if (fromZone)
+            fromZone.nurseIds = fromZone.nurseIds.filter((nid) => nid !== id);
+          const zone = state.zones.find((z) => z.id === toZone);
+          if (zone) {
+            if (index === undefined) zone.nurseIds.push(id);
+            else zone.nurseIds.splice(index, 0, id);
+          }
+        }),
+      removeNurse: (id) =>
+        set((state) => {
+          delete state.nurses[id];
+          state.zones.forEach(
+            (z) => (z.nurseIds = z.nurseIds.filter((nid) => nid !== id))
+          );
+        }),
+      addZone: (name) =>
+        set((state) => {
+          const id = uuid();
+          state.zones.push({ id, name, order: state.zones.length, nurseIds: [] });
+        }),
+      updateZone: (id, data) =>
+        set((state) => {
+          const z = state.zones.find((z) => z.id === id);
+          if (z) Object.assign(z, data);
+        }),
+      updateSettings: (data) =>
+        set((state) => ({ settings: { ...state.settings, ...data } })),
+      setWeather: (w) => set((state) => ({ weather: { ...state.weather, ...w } })),
+      addAncillary: (role, names, note) =>
+        set((state) => {
+          state.ancillary.push({ id: uuid(), role, names, note });
+        }),
+    }),
+    {
+      name: 'staffboard',
+      version: 2,
+      migrate: (state) => state as BoardState,
     }
-  }),
-  removeNurse: (id) => set((state) => {
-    delete state.nurses[id];
-    state.zones.forEach((z) => z.nurseIds = z.nurseIds.filter((nid) => nid !== id));
-  }),
-  addZone: (name) => set((state) => {
-    const id = uuid();
-    state.zones.push({ id, name, order: state.zones.length, nurseIds: [] });
-  }),
-  updateZone: (id, data) => set((state) => {
-    const z = state.zones.find((z) => z.id === id);
-    if (z) Object.assign(z, data);
-  }),
-  setTheme: (t) => set(() => ({ theme: t }))
-}), {
-  name: 'staffboard',
-  version: 1,
-  migrate: (state) => state as BoardState
-}));
+  )
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -10,7 +10,15 @@
 html,body,#root{height:100%;margin:0;}
 body{background:var(--bg);color:var(--text);font-family:sans-serif;font-size:var(--f);}
 
-.board{display:flex;gap:var(--gap);padding:var(--gap);overflow-x:auto;}
+.app-root{width:1920px;height:1080px;display:flex;flex-direction:column;overflow:hidden;}
+.main-grid{flex:1;display:grid;grid-template-columns:72% 28%;height:100%;}
+.right-rail{display:flex;flex-direction:column;gap:var(--gap);padding:var(--gap);overflow:hidden;}
+.rail-card{background:var(--panel);padding:var(--gap);border-radius:var(--radius);min-height:100px;}
+.time-weather .clock{font-size:var(--f-xl);line-height:1;}
+.topbar.tv .search{display:none;}
+.topbar.tv button:first-child{display:none;}
+
+.board{display:flex;gap:var(--gap);padding:var(--gap);overflow-x:auto;height:100%;}
 .zone{background:var(--panel);padding:var(--gap);border-radius:var(--radius);min-width:220px;flex:0 0 auto;}
 .zone-title{margin-top:0;font-size:var(--f-lg);} 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,32 +1,69 @@
-export type Role = 'RN' | 'LPN' | 'Tech' | 'Charge' | 'UnitSecretary';
+export type Role =
+  | 'RN'
+  | 'Charge RN'
+  | 'Tech'
+  | 'MD'
+  | 'APP'
+  | 'RT'
+  | 'Rad'
+  | 'Transport'
+  | 'Scribe'
+  | 'Other';
 
-export interface Nurse {
+export interface StaffBase {
   id: string;
   firstName: string;
   lastName: string;
-  rfNumber?: string;
   role: Role;
+  rfNumber?: string;
   notes?: string;
-  studentTag?: string | null;
-  offAt?: string | null;      // ISO
+}
+
+export interface Nurse extends StaffBase {
   status: 'active' | 'off';
+  studentTag?: string | null;
   shiftStart?: string | null; // ISO
-  shiftEnd?: string | null;   // ISO
+  shiftEnd?: string | null; // ISO
+  offAt?: string | null; // legacy
 }
 
 export interface Zone {
   id: string;
   name: string;
-  color?: string;   // accent
+  capacity?: number;
   order: number;
   nurseIds: string[];
+}
+
+export interface Settings {
+  theme: 'dark' | 'light' | 'auto';
+  tvMode: boolean;
+  showSeconds: boolean;
+  clock24h: boolean;
+  weatherEnabled: boolean;
+  weatherEndpoint?: string;
+  weatherLocationLabel?: string;
+  autoPromoteIncoming: boolean;
+  retainOffgoingMinutes: number;
+}
+
+export interface WeatherState {
+  location: string;
+  tempC?: number;
+  tempF?: number;
+  condition?: 'Clear' | 'Clouds' | 'Rain' | 'Snow' | 'Fog' | 'Wind' | 'Unknown';
+  highF?: number;
+  lowF?: number;
+  updatedAt?: string;
 }
 
 export interface BoardState {
   zones: Zone[];
   nurses: Record<string, Nurse>;
-  theme: 'dark' | 'light';
-  privacy: { mainBoardNameFormat: 'first-lastInitial' | 'full'; };
-  ui: { density: 'compact' | 'comfortable'; };
+  ancillary: { id: string; role: Role; names: string[]; note?: string }[];
+  settings: Settings;
+  weather: WeatherState;
+  privacy: { mainBoardNameFormat: 'first-lastInitial' | 'full' };
+  ui: { density: 'compact' | 'comfortable' };
   version: number;
 }


### PR DESCRIPTION
## Summary
- add ViewportScaler to keep 1920×1080 canvas and scale to fit browser
- introduce TV mode and right-side rail with time, weather, incoming/off-going, and ancillary cards
- centralize settings/weather in store and provide schedule bucket hooks

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689febd1ed688327a26e75e7e430a4a6