### PR TITLE
feat: add weather unit toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Uses the [Open-Meteo](https://open-meteo.com/) API (no key) for live conditions.
 - Theme toggle (🌓) persists across sessions.
 - Search by name, RF number, role or notes from the top bar.
 - Search by name, Hospital ID, RF number, role or notes from the top bar.
-- Export/Import data via browser dev tools using localStorage key `staffboard_v3`.
-- If the app crashes, an overlay offers **Reload** or **Reset Local Data** (clears `staffboard_v3`).
+- Export/Import data via browser dev tools using localStorage key `staffboard_v4`.
+- If the app crashes, an overlay offers **Reload** or **Reset Local Data** (clears `staffboard_v4`).
 
 ## Hospital ID
 
@@ -44,3 +44,7 @@ Each nurse can have a unique numeric Hospital ID. When adding a nurse without an
 ## Shift Planner (v2.6)
 
 An experimental planner for building daily or weekly coverage. Drag nurses into zone/role cells, review the last five assignments and publish days to append to history. Includes basic rule checks, optional self-scheduling windows and a lightweight swap request queue.
+
+## Planner and Settings
+
+Use the Planner tab to drag nurses into zone/time slots and adjust DTO flags before publishing to history. The Settings panel manages nurse records and visual preferences, including a Fahrenheit/Celsius toggle that updates all weather displays.

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -28,6 +28,7 @@ const Settings: React.FC<Props> = ({ onClose }) => {
     lat: settings.weatherLat ?? 38.2473,
     lon: settings.weatherLon ?? -85.7579,
     refresh: settings.weatherRefreshMinutes ?? 10,
+    unit: settings.weatherUnit || 'F',
     endpoint: settings.weatherEndpoint || '',
   });
   const [weatherError, setWeatherError] = useState<string | null>(null);
@@ -149,6 +150,31 @@ const Settings: React.FC<Props> = ({ onClose }) => {
             Custom JSON URL
           </label>
         </div>
+        <div>
+          Units:
+          <label>
+            <input
+              type="radio"
+              value="F"
+              checked={weatherDraft.unit === 'F'}
+              onChange={(e) =>
+                setWeatherDraft({ ...weatherDraft, unit: e.target.value as 'F' | 'C' })
+              }
+            />{' '}
+            Fahrenheit
+          </label>
+          <label>
+            <input
+              type="radio"
+              value="C"
+              checked={weatherDraft.unit === 'C'}
+              onChange={(e) =>
+                setWeatherDraft({ ...weatherDraft, unit: e.target.value as 'F' | 'C' })
+              }
+            />{' '}
+            Celsius
+          </label>
+        </div>
         {weatherDraft.provider === 'custom' && (
           <input
             placeholder="Endpoint URL"
@@ -214,6 +240,7 @@ const Settings: React.FC<Props> = ({ onClose }) => {
               weatherLat: weatherDraft.lat,
               weatherLon: weatherDraft.lon,
               weatherRefreshMinutes: weatherDraft.refresh,
+              weatherUnit: weatherDraft.unit as 'F' | 'C',
               weatherEndpoint:
                 weatherDraft.provider === 'custom'
                   ? weatherDraft.endpoint

--- a/src/components/card/CardTimeWeather.tsx
+++ b/src/components/card/CardTimeWeather.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useStore } from '../../store';
 import { useWeather } from '../../hooks/useWeather';
-import { conditionIcon } from '../../lib/weather';
+import { conditionIcon, formatTemp } from '../../lib/weather';
 
 const pad = (n: number) => n.toString().padStart(2, '0');
 
@@ -47,12 +47,12 @@ const CardTimeWeather: React.FC = () => {
             <div className="loc">{weather.location}</div>
             <div className="current">
               <span className="icon">{conditionIcon(weather.condition)}</span>
-              <span className="temp">{Math.round(weather.tempF)}&deg;F</span>
+              <span className="temp">{formatTemp(weather.tempF, settings.weatherUnit || 'F')}</span>
               <span className="cond">{weather.condition}</span>
             </div>
             {weather.highF !== undefined && weather.lowF !== undefined && (
               <div className="range">
-                H {Math.round(weather.highF)}&deg; / L {Math.round(weather.lowF)}&deg;
+                H {formatTemp(weather.highF, settings.weatherUnit || 'F')} / L {formatTemp(weather.lowF, settings.weatherUnit || 'F')}
               </div>
             )}
             {updatedStr && (

--- a/src/lib/weather.test.ts
+++ b/src/lib/weather.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { formatTemp } from './weather';
+
+describe('formatTemp', () => {
+  it('formats Fahrenheit by default', () => {
+    expect(formatTemp(72, 'F')).toBe('72°F');
+  });
+  it('converts to Celsius when requested', () => {
+    expect(formatTemp(41, 'C')).toBe('5°C');
+  });
+});

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -1,5 +1,7 @@
 import { WeatherState } from '../types';
 
+export type TempUnit = 'F' | 'C';
+
 /** Map Open-Meteo weather codes to coarse conditions */
 export function codeToCondition(code: number): WeatherState['condition'] {
   if ([0].includes(code)) return 'Clear';
@@ -31,5 +33,16 @@ export function conditionIcon(c: WeatherState['condition']): string {
     default:
       return '❔';
   }
+}
+
+export function convertTemp(tempF: number | undefined, unit: TempUnit): number | undefined {
+  if (tempF === undefined) return undefined;
+  return unit === 'F' ? tempF : ((tempF - 32) * 5) / 9;
+}
+
+export function formatTemp(tempF: number | undefined, unit: TempUnit): string {
+  const t = convertTemp(tempF, unit);
+  if (t === undefined) return '';
+  return `${Math.round(t)}°${unit}`;
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -190,6 +190,7 @@ const demoState: BoardState = ensurePinnedZones({
     weatherLat: 38.2473,
     weatherLon: -85.7579,
     weatherRefreshMinutes: 10,
+    weatherUnit: 'F',
     autoPromoteIncoming: false,
     retainOffgoingMinutes: 30,
   } as any,
@@ -209,7 +210,7 @@ const demoState: BoardState = ensurePinnedZones({
   },
   swapRequests: [],
 
-  version: 3,
+  version: 4,
 });
 
 export const useStore = create<Store>((set, get) => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,7 @@ export interface Settings {
   weatherLon?: number;                  // default -85.7579
   weatherRefreshMinutes?: number;       // default 10
   weatherEndpoint?: string;
+  weatherUnit?: 'F' | 'C';              // Fahrenheit or Celsius
   autoPromoteIncoming: boolean;
   retainOffgoingMinutes: number;
 }


### PR DESCRIPTION
## Summary
- add weatherUnit setting with F/C toggle
- centralize temperature conversion/formatting
- use unit preference in weather card and bump storage version
- document planner & settings and update storage key in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0e6a4a1888327950d2224602df7df